### PR TITLE
Use new credentials for cardinal artifacts

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,10 +43,10 @@ dependencies {
 rootProject.allprojects {
     repositories {
         maven {
-            url  "https://cardinalcommerce.bintray.com/android"
+            url "https://cardinalcommerceprod.jfrog.io/artifactory/android"
             credentials {
-                username 'braintree-team-sdk@cardinalcommerce'
-                password '220cc9476025679c4e5c843666c27d97cfb0f951'
+                username 'braintree_team_sdk'
+                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
             }
         }
     }


### PR DESCRIPTION
Update the credentials according to the specification in the original library: https://github.com/braintree/braintree-android-drop-in/issues/249